### PR TITLE
patch finatra to use shaded jackson

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ project/boot/
 project/plugins/project/
 sbt-launch.jar
 target/
+lib/*

--- a/benchmarks/src/test/scala/com/twitter/finatra/json/benchmarks/JsonBenchmark.scala
+++ b/benchmarks/src/test/scala/com/twitter/finatra/json/benchmarks/JsonBenchmark.scala
@@ -1,6 +1,6 @@
 package com.twitter.finatra.json.benchmarks
 
-import com.fasterxml.jackson.module.scala.JacksonModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.JacksonModule
 import com.twitter.finatra.StdBenchAnnotations
 import com.twitter.finatra.benchmarks.domain.{TestDemographic, TestFormat}
 import com.twitter.finatra.json.FinatraObjectMapper

--- a/examples/benchmark-server/src/main/scala/com/twitter/finatra/http/benchmark/FinagleBenchmarkServer.scala
+++ b/examples/benchmark-server/src/main/scala/com/twitter/finatra/http/benchmark/FinagleBenchmarkServer.scala
@@ -1,7 +1,7 @@
 package com.twitter.finatra.http.benchmark
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ObjectMapper
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.twitter.finagle.http.{HttpMuxer, Request, Response}
 import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.finagle.tracing.NullTracer

--- a/examples/streaming-example/src/test/scala/com/twitter/streaming/StreamingServerFeatureTest.scala
+++ b/examples/streaming-example/src/test/scala/com/twitter/streaming/StreamingServerFeatureTest.scala
@@ -1,6 +1,6 @@
 package com.twitter.streaming
 
-import com.fasterxml.jackson.databind.JsonNode
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JsonNode
 import com.twitter.conversions.DurationOps._
 import com.twitter.finagle.http.{Request, Response, Status}
 import com.twitter.finatra.http.{EmbeddedHttpServer, StreamingJsonTestHelper}

--- a/examples/twitter-clone/src/test/scala/finatra/quickstart/TwitterCloneExternalTest.scala
+++ b/examples/twitter-clone/src/test/scala/finatra/quickstart/TwitterCloneExternalTest.scala
@@ -1,7 +1,7 @@
 package finatra.quickstart
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.node.ObjectNode
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JsonNode
+import __foursquare_shaded__.com.fasterxml.jackson.databind.node.ObjectNode
 import com.google.inject.Stage
 import com.twitter.finagle.http.Status._
 import com.twitter.finatra.http.EmbeddedHttpServer

--- a/http/src/main/scala/com/twitter/finatra/http/internal/exceptions/json/JsonParseExceptionMapper.scala
+++ b/http/src/main/scala/com/twitter/finatra/http/internal/exceptions/json/JsonParseExceptionMapper.scala
@@ -1,6 +1,6 @@
 package com.twitter.finatra.http.internal.exceptions.json
 
-import com.fasterxml.jackson.core.JsonParseException
+import __foursquare_shaded__.com.fasterxml.jackson.core.JsonParseException
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finatra.http.exceptions.ExceptionMapper
 import com.twitter.finatra.http.response.ResponseBuilder

--- a/http/src/main/scala/com/twitter/finatra/http/internal/marshalling/DefaultMessageBodyReaderImpl.scala
+++ b/http/src/main/scala/com/twitter/finatra/http/internal/marshalling/DefaultMessageBodyReaderImpl.scala
@@ -1,6 +1,6 @@
 package com.twitter.finatra.http.internal.marshalling
 
-import com.fasterxml.jackson.databind.node.ObjectNode
+import __foursquare_shaded__.com.fasterxml.jackson.databind.node.ObjectNode
 import com.google.inject.Injector
 import com.twitter.finagle.http.{MediaType, Message, Request}
 import com.twitter.finatra.http.marshalling.{DefaultMessageBodyReader, MessageBodyReader}

--- a/http/src/main/scala/com/twitter/finatra/http/internal/marshalling/RequestInjectableValues.scala
+++ b/http/src/main/scala/com/twitter/finatra/http/internal/marshalling/RequestInjectableValues.scala
@@ -1,7 +1,7 @@
 package com.twitter.finatra.http.internal.marshalling
 
-import com.fasterxml.jackson.databind.`type`.SimpleType
-import com.fasterxml.jackson.databind.{
+import __foursquare_shaded__.com.fasterxml.jackson.databind.`type`.SimpleType
+import __foursquare_shaded__.com.fasterxml.jackson.databind.{
   BeanProperty,
   DeserializationContext,
   InjectableValues,

--- a/http/src/main/scala/com/twitter/finatra/http/jsonpatch/JsonPatchOperator.scala
+++ b/http/src/main/scala/com/twitter/finatra/http/jsonpatch/JsonPatchOperator.scala
@@ -1,8 +1,8 @@
 package com.twitter.finatra.http.jsonpatch
 
-import com.fasterxml.jackson.core.JsonPointer
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.node.{ArrayNode, ObjectNode}
+import __foursquare_shaded__.com.fasterxml.jackson.core.JsonPointer
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JsonNode
+import __foursquare_shaded__.com.fasterxml.jackson.databind.node.{ArrayNode, ObjectNode}
 import com.twitter.finatra.json.FinatraObjectMapper
 import scala.annotation.tailrec
 import javax.inject.{Inject, Singleton}

--- a/http/src/main/scala/com/twitter/finatra/http/jsonpatch/JsonPatchUtility.scala
+++ b/http/src/main/scala/com/twitter/finatra/http/jsonpatch/JsonPatchUtility.scala
@@ -1,6 +1,6 @@
 package com.twitter.finatra.http.jsonpatch
 
-import com.fasterxml.jackson.databind.JsonNode
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JsonNode
 
 /**
  * Apply each JSON Patch operation to target JSON document

--- a/http/src/main/scala/com/twitter/finatra/http/jsonpatch/PatchOperation.scala
+++ b/http/src/main/scala/com/twitter/finatra/http/jsonpatch/PatchOperation.scala
@@ -1,7 +1,7 @@
 package com.twitter.finatra.http.jsonpatch
 
-import com.fasterxml.jackson.core.JsonPointer
-import com.fasterxml.jackson.databind.JsonNode
+import __foursquare_shaded__.com.fasterxml.jackson.core.JsonPointer
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JsonNode
 
 /**
  * Operations compose JSON Patch, apply to a target JSON document

--- a/http/src/main/scala/com/twitter/finatra/http/marshalling/MessageBodyReader.scala
+++ b/http/src/main/scala/com/twitter/finatra/http/marshalling/MessageBodyReader.scala
@@ -1,6 +1,6 @@
 package com.twitter.finatra.http.marshalling
 
-import com.fasterxml.jackson.databind.ObjectReader
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ObjectReader
 import com.twitter.finagle.http.Message
 
 object MessageBodyReader {

--- a/http/src/test/scala/com/twitter/finatra/http/EmbeddedHttpServer.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/EmbeddedHttpServer.scala
@@ -1,6 +1,6 @@
 package com.twitter.finatra.http
 
-import com.fasterxml.jackson.databind.JsonNode
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JsonNode
 import com.google.inject.Stage
 import com.twitter.app.GlobalFlag
 import com.twitter.finagle.http.{MediaType, Method, Status, _}

--- a/http/src/test/scala/com/twitter/finatra/http/JsonAwareEmbeddedHttpClient.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/JsonAwareEmbeddedHttpClient.scala
@@ -1,6 +1,6 @@
 package com.twitter.finatra.http
 
-import com.fasterxml.jackson.databind.JsonNode
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JsonNode
 import com.twitter.conversions.DurationOps._
 import com.twitter.finagle.http.{Request, Response, Status}
 import com.twitter.finatra.json.{FinatraObjectMapper, JsonDiff}

--- a/http/src/test/scala/com/twitter/finatra/http/StreamingJsonTestHelper.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/StreamingJsonTestHelper.scala
@@ -1,6 +1,6 @@
 package com.twitter.finatra.http
 
-import com.fasterxml.jackson.databind.ObjectWriter
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ObjectWriter
 import com.twitter.finagle.http.Request
 import com.twitter.finatra.json.FinatraObjectMapper
 import com.twitter.io.Buf

--- a/http/src/test/scala/com/twitter/finatra/http/tests/integration/doeverything/main/domain/DomainTestUserReader.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/tests/integration/doeverything/main/domain/DomainTestUserReader.scala
@@ -1,6 +1,6 @@
 package com.twitter.finatra.http.tests.integration.doeverything.main.domain
 
-import com.fasterxml.jackson.databind.JsonNode
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JsonNode
 import com.twitter.finagle.http.Message
 import com.twitter.finatra.http.marshalling.mapper._
 import com.twitter.finatra.http.marshalling.MessageBodyReader

--- a/http/src/test/scala/com/twitter/finatra/http/tests/integration/doeverything/test/DoEverythingServerFeatureTest.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/tests/integration/doeverything/test/DoEverythingServerFeatureTest.scala
@@ -1,6 +1,6 @@
 package com.twitter.finatra.http.tests.integration.doeverything.test
 
-import com.fasterxml.jackson.databind.JsonNode
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JsonNode
 import com.google.inject.name.Names
 import com.google.inject.{Key, TypeLiteral}
 import com.twitter.finagle.http.Method._

--- a/http/src/test/scala/com/twitter/finatra/http/tests/integration/tweetexample/test/TweetsControllerIntegrationTest.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/tests/integration/tweetexample/test/TweetsControllerIntegrationTest.scala
@@ -1,6 +1,6 @@
 package com.twitter.finatra.http.tests.integration.tweetexample.test
 
-import com.fasterxml.jackson.databind.JsonNode
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JsonNode
 import com.twitter.finagle.http.{Fields, Status}
 import com.twitter.finatra.http.tests.integration.tweetexample.main.TweetsEndpointServer
 import com.twitter.finatra.http.tests.integration.tweetexample.main.domain.Tweet

--- a/http/src/test/scala/com/twitter/finatra/http/tests/marshalling/MessageBodyManagerTest.scala
+++ b/http/src/test/scala/com/twitter/finatra/http/tests/marshalling/MessageBodyManagerTest.scala
@@ -1,6 +1,6 @@
 package com.twitter.finatra.http.tests.marshalling
 
-import com.fasterxml.jackson.databind.JsonNode
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JsonNode
 import com.twitter.finagle.http.{Fields, MediaType, Message, Request, Response}
 import com.twitter.finatra.http.TestMessageBodyWriterAnn
 import com.twitter.finatra.http.marshalling.{DefaultMessageBodyReader, DefaultMessageBodyWriter, MessageBodyComponent, MessageBodyManager, MessageBodyReader, MessageBodyWriter, WriterResponse}

--- a/httpclient/src/main/scala/com/twitter/finatra/httpclient/HttpClient.scala
+++ b/httpclient/src/main/scala/com/twitter/finatra/httpclient/HttpClient.scala
@@ -1,6 +1,6 @@
 package com.twitter.finatra.httpclient
 
-import com.fasterxml.jackson.databind.ObjectReader
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ObjectReader
 import com.twitter.finagle.Service
 import com.twitter.finagle.http.{Message, Request, Response, Status}
 import com.twitter.finagle.service.RetryPolicy

--- a/httpclient/src/test/scala/com/twitter/finatra/httpclient/HttpClientIntegrationTest.scala
+++ b/httpclient/src/test/scala/com/twitter/finatra/httpclient/HttpClientIntegrationTest.scala
@@ -1,6 +1,6 @@
 package com.twitter.finatra.httpclient
 
-import com.fasterxml.jackson.databind.JsonNode
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JsonNode
 import com.google.inject.Provides
 import com.twitter.finagle.Service
 import com.twitter.finagle.http.{Request, Response, Status}

--- a/inject/inject-logback/src/test/scala/com/twitter/inject/logback/AppendTestHttpServerFeatureTest.scala
+++ b/inject/inject-logback/src/test/scala/com/twitter/inject/logback/AppendTestHttpServerFeatureTest.scala
@@ -5,9 +5,9 @@ import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.classic.{BasicConfigurator, Level, LoggerContext}
 import ch.qos.logback.core.encoder.LayoutWrappingEncoder
 import ch.qos.logback.core.{ConsoleAppender, LogbackAsyncAppenderBase, TestLogbackAsyncAppender}
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ObjectMapper
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.DefaultScalaModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 import com.twitter.finagle.http.{Request, Status}
 import com.twitter.finagle.stats.InMemoryStatsReceiver
 import com.twitter.finatra.http.routing.HttpRouter

--- a/inject/inject-slf4j/src/main/scala/com/twitter/inject/Logging.scala
+++ b/inject/inject-slf4j/src/main/scala/com/twitter/inject/Logging.scala
@@ -1,6 +1,6 @@
 package com.twitter.inject
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.twitter.util.{Future, Return, Stopwatch, Throw}
 import scala.util.control.NonFatal
 

--- a/jackson/src/main/scala/com/fasterxml/jackson/databind/ObjectMapperCopier.scala
+++ b/jackson/src/main/scala/com/fasterxml/jackson/databind/ObjectMapperCopier.scala
@@ -1,6 +1,6 @@
-package com.fasterxml.jackson.databind
+package __foursquare_shaded__.com.fasterxml.jackson.databind
 
-import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 
 object ObjectMapperCopier {
 

--- a/jackson/src/main/scala/com/twitter/finatra/json/FinatraObjectMapper.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/FinatraObjectMapper.scala
@@ -1,9 +1,9 @@
 package com.twitter.finatra.json
 
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.databind.util.ByteBufferBackedInputStream
-import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import __foursquare_shaded__.com.fasterxml.jackson.core.JsonParser
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.databind.util.ByteBufferBackedInputStream
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 import com.google.inject.Injector
 import com.twitter.finatra.json.internal.serde.ArrayElementsOnNewLinesPrettyPrinter
 import com.twitter.finatra.json.modules.FinatraJacksonModule

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/exceptions/CaseClassMappingException.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/exceptions/CaseClassMappingException.scala
@@ -1,6 +1,6 @@
 package com.twitter.finatra.json.internal.caseclass.exceptions
 
-import com.fasterxml.jackson.databind.JsonMappingException
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JsonMappingException
 
 case class CaseClassMappingException(
   validationExceptions: Set[CaseClassValidationException] = Set()

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/exceptions/FinatraJsonMappingException.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/exceptions/FinatraJsonMappingException.scala
@@ -1,6 +1,6 @@
 package com.twitter.finatra.json.internal.caseclass.exceptions
 
-import com.fasterxml.jackson.databind.JsonMappingException
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JsonMappingException
 
 /**
  * Exception for handling Finatra-specific errors that may otherwise be valid

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/guice/GuiceInjectableValues.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/guice/GuiceInjectableValues.scala
@@ -1,6 +1,6 @@
 package com.twitter.finatra.json.internal.caseclass.guice
 
-import com.fasterxml.jackson.databind.{BeanProperty, DeserializationContext, InjectableValues}
+import __foursquare_shaded__.com.fasterxml.jackson.databind.{BeanProperty, DeserializationContext, InjectableValues}
 import com.google.inject.{Injector, Key}
 
 private[json] class GuiceInjectableValues(injector: Injector) extends InjectableValues {

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/jackson/CaseClassDeserializer.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/jackson/CaseClassDeserializer.scala
@@ -1,13 +1,13 @@
 package com.twitter.finatra.json.internal.caseclass.jackson
 
-import com.fasterxml.jackson.core.{
+import __foursquare_shaded__.com.fasterxml.jackson.core.{
   JsonParseException,
   JsonParser,
   JsonProcessingException,
   JsonToken
 }
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.databind.exc.{InvalidFormatException, MismatchedInputException}
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.databind.exc.{InvalidFormatException, MismatchedInputException}
 import com.twitter.finatra.json.internal.caseclass.exceptions.CaseClassValidationException.PropertyPath
 import com.twitter.finatra.json.internal.caseclass.exceptions._
 import com.twitter.finatra.response.JsonCamelCase

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/jackson/CaseClassDeserializers.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/jackson/CaseClassDeserializers.scala
@@ -1,7 +1,7 @@
 package com.twitter.finatra.json.internal.caseclass.jackson
 
-import com.fasterxml.jackson.databind.deser.Deserializers
-import com.fasterxml.jackson.databind.{BeanDescription, DeserializationConfig, JavaType}
+import __foursquare_shaded__.com.fasterxml.jackson.databind.deser.Deserializers
+import __foursquare_shaded__.com.fasterxml.jackson.databind.{BeanDescription, DeserializationConfig, JavaType}
 import com.twitter.finatra.validation.{CaseClassValidationProvider, ValidationProvider}
 
 private object CaseClassDeserializers {

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/jackson/CaseClassField.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/jackson/CaseClassField.scala
@@ -1,12 +1,12 @@
 package com.twitter.finatra.json.internal.caseclass.jackson
 
-import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.core.ObjectCodec
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.databind.`type`.TypeFactory
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import com.fasterxml.jackson.databind.node.TreeTraversingParser
-import com.fasterxml.jackson.databind.util.ClassUtil
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.JsonProperty
+import __foursquare_shaded__.com.fasterxml.jackson.core.ObjectCodec
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.databind.`type`.TypeFactory
+import __foursquare_shaded__.com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import __foursquare_shaded__.com.fasterxml.jackson.databind.node.TreeTraversingParser
+import __foursquare_shaded__.com.fasterxml.jackson.databind.util.ClassUtil
 import com.twitter.finatra.json.internal.caseclass.exceptions.{CaseClassValidationException, FinatraJsonMappingException}
 import com.twitter.finatra.json.internal.caseclass.utils.{DefaultMethodUtils, FieldInjection}
 import com.twitter.finatra.request.{FormParam, Header, QueryParam}

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/jackson/CaseClassModule.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/jackson/CaseClassModule.scala
@@ -1,6 +1,6 @@
 package com.twitter.finatra.json.internal.caseclass.jackson
 
-import com.fasterxml.jackson.module.scala._
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala._
 
 private[finatra] object CaseClassModule extends JacksonModule {
   override def getModuleName: String = getClass.getName

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/jackson/ImmutableAnnotations.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/jackson/ImmutableAnnotations.scala
@@ -1,6 +1,6 @@
 package com.twitter.finatra.json.internal.caseclass.jackson
 
-import com.fasterxml.jackson.databind.util.Annotations
+import __foursquare_shaded__.com.fasterxml.jackson.databind.util.Annotations
 import com.twitter.inject.conversions.seq._
 import java.lang.annotation.Annotation
 

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/jackson/JacksonTypes.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/jackson/JacksonTypes.scala
@@ -1,7 +1,7 @@
 package com.twitter.finatra.json.internal.caseclass.jackson
 
-import com.fasterxml.jackson.databind.JavaType
-import com.fasterxml.jackson.databind.`type`.{ArrayType, TypeBindings, TypeFactory}
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JavaType
+import __foursquare_shaded__.com.fasterxml.jackson.databind.`type`.{ArrayType, TypeBindings, TypeFactory}
 
 private[json] object JacksonTypes {
 

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/jackson/JacksonUtils.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/jackson/JacksonUtils.scala
@@ -1,7 +1,7 @@
 package com.twitter.finatra.json.internal.caseclass.jackson
 
-import com.fasterxml.jackson.core.JsonProcessingException
-import com.fasterxml.jackson.databind.JsonMappingException
+import __foursquare_shaded__.com.fasterxml.jackson.core.JsonProcessingException
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JsonMappingException
 import com.twitter.finatra.json.internal.caseclass.exceptions.FinatraJsonMappingException
 import com.twitter.inject.Logging
 

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/utils/FieldInjection.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/utils/FieldInjection.scala
@@ -1,9 +1,9 @@
 package com.twitter.finatra.json.internal.caseclass.utils
 
-import com.fasterxml.jackson.core.ObjectCodec
-import com.fasterxml.jackson.databind.deser.impl.ValueInjector
-import com.fasterxml.jackson.databind.exc.InvalidDefinitionException
-import com.fasterxml.jackson.databind.{DeserializationContext, JavaType, PropertyName}
+import __foursquare_shaded__.com.fasterxml.jackson.core.ObjectCodec
+import __foursquare_shaded__.com.fasterxml.jackson.databind.deser.impl.ValueInjector
+import __foursquare_shaded__.com.fasterxml.jackson.databind.exc.InvalidDefinitionException
+import __foursquare_shaded__.com.fasterxml.jackson.databind.{DeserializationContext, JavaType, PropertyName}
 import com.google.inject.{BindingAnnotation, ConfigurationException, Key}
 import com.twitter.finagle.http.Request
 import com.twitter.finatra.json.internal.caseclass.exceptions.{JsonInjectException, JsonInjectionNotSupportedException}

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/utils/JacksonToGuiceTypeConverter.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/utils/JacksonToGuiceTypeConverter.scala
@@ -1,6 +1,6 @@
 package com.twitter.finatra.json.internal.caseclass.utils
 
-import com.fasterxml.jackson.databind.JavaType
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JavaType
 import com.google.inject.util.Types
 import java.lang.reflect.Type
 

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/wrapped/WrappedValueSerializer.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/caseclass/wrapped/WrappedValueSerializer.scala
@@ -1,8 +1,8 @@
 package com.twitter.finatra.json.internal.caseclass.wrapped
 
-import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.databind.SerializerProvider
-import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import __foursquare_shaded__.com.fasterxml.jackson.core.JsonGenerator
+import __foursquare_shaded__.com.fasterxml.jackson.databind.SerializerProvider
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ser.std.StdSerializer
 import com.twitter.inject.domain.WrappedValue
 
 private[finatra] object WrappedValueSerializer

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/serde/ArrayElementsOnNewLinesPrettyPrinter.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/serde/ArrayElementsOnNewLinesPrettyPrinter.scala
@@ -1,7 +1,7 @@
 package com.twitter.finatra.json.internal.serde
 
-import com.fasterxml.jackson.core.util.DefaultIndenter
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
+import __foursquare_shaded__.com.fasterxml.jackson.core.util.DefaultIndenter
+import __foursquare_shaded__.com.fasterxml.jackson.core.util.DefaultPrettyPrinter
 
 private[finatra] object ArrayElementsOnNewLinesPrettyPrinter extends DefaultPrettyPrinter {
   _arrayIndenter = DefaultIndenter.SYSTEM_LINEFEED_INSTANCE

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/serde/DurationStringDeserializer.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/serde/DurationStringDeserializer.scala
@@ -1,7 +1,7 @@
 package com.twitter.finatra.json.internal.serde
 
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.{DeserializationContext, JsonDeserializer}
+import __foursquare_shaded__.com.fasterxml.jackson.core.JsonParser
+import __foursquare_shaded__.com.fasterxml.jackson.databind.{DeserializationContext, JsonDeserializer}
 import com.twitter.finatra.json.internal.caseclass.exceptions.FinatraJsonMappingException
 import com.twitter.util.Duration
 

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/serde/DurationStringSerializer.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/serde/DurationStringSerializer.scala
@@ -1,8 +1,8 @@
 package com.twitter.finatra.json.internal.serde
 
-import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.databind.SerializerProvider
-import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import __foursquare_shaded__.com.fasterxml.jackson.core.JsonGenerator
+import __foursquare_shaded__.com.fasterxml.jackson.databind.SerializerProvider
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ser.std.StdSerializer
 import com.twitter.util.Duration
 
 private[finatra] object DurationStringSerializer

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/serde/JodaDatetimeDeserializer.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/serde/JodaDatetimeDeserializer.scala
@@ -1,9 +1,9 @@
 package com.twitter.finatra.json.internal.serde
 
-import com.fasterxml.jackson.core.{JsonParser, JsonToken}
-import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaDateFormat
-import com.fasterxml.jackson.datatype.joda.deser.JodaDateDeserializerBase
+import __foursquare_shaded__.com.fasterxml.jackson.core.{JsonParser, JsonToken}
+import __foursquare_shaded__.com.fasterxml.jackson.databind.DeserializationContext
+import __foursquare_shaded__.com.fasterxml.jackson.datatype.joda.cfg.JacksonJodaDateFormat
+import __foursquare_shaded__.com.fasterxml.jackson.datatype.joda.deser.JodaDateDeserializerBase
 import com.twitter.finatra.json.internal.caseclass.exceptions.FinatraJsonMappingException
 import com.twitter.util.{Return, Try}
 import org.joda.time.{DateTime, DateTimeZone}

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/serde/JodaDurationMillisSerializer.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/serde/JodaDurationMillisSerializer.scala
@@ -1,8 +1,8 @@
 package com.twitter.finatra.json.internal.serde
 
-import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.databind.SerializerProvider
-import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import __foursquare_shaded__.com.fasterxml.jackson.core.JsonGenerator
+import __foursquare_shaded__.com.fasterxml.jackson.databind.SerializerProvider
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ser.std.StdSerializer
 import org.joda.time.Duration
 
 private[finatra] object JodaDurationMillisSerializer

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/serde/LongKeyDeserializer.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/serde/LongKeyDeserializer.scala
@@ -1,8 +1,8 @@
 package com.twitter.finatra.json.internal.serde
 
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.databind.deser.KeyDeserializers
-import com.fasterxml.jackson.module.scala.JacksonModule
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.databind.deser.KeyDeserializers
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.JacksonModule
 import com.twitter.inject.domain.WrappedValue
 import org.json4s.reflect.{classDescribable, ClassDescriptor, Reflector}
 

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/serde/SerDeSimpleModule.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/serde/SerDeSimpleModule.scala
@@ -1,7 +1,7 @@
 package com.twitter.finatra.json.internal.serde
 
-import com.fasterxml.jackson.databind.module.SimpleModule
-import com.fasterxml.jackson.datatype.joda.cfg.FormatConfig
+import __foursquare_shaded__.com.fasterxml.jackson.databind.module.SimpleModule
+import __foursquare_shaded__.com.fasterxml.jackson.datatype.joda.cfg.FormatConfig
 import com.twitter.finatra.json.internal.caseclass.wrapped.WrappedValueSerializer
 import com.twitter.{util => ctu}
 import org.joda.time.DateTime

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/serde/TimeStringDeserializer.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/serde/TimeStringDeserializer.scala
@@ -1,9 +1,9 @@
 package com.twitter.finatra.json.internal.serde
 
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.deser.ContextualDeserializer
-import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer
-import com.fasterxml.jackson.databind.{BeanProperty, DeserializationContext, JsonDeserializer}
+import __foursquare_shaded__.com.fasterxml.jackson.core.JsonParser
+import __foursquare_shaded__.com.fasterxml.jackson.databind.deser.ContextualDeserializer
+import __foursquare_shaded__.com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer
+import __foursquare_shaded__.com.fasterxml.jackson.databind.{BeanProperty, DeserializationContext, JsonDeserializer}
 import com.twitter.util.{Time, TimeFormat}
 import java.util.{Locale, TimeZone}
 

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/serde/TimeStringSerializer.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/serde/TimeStringSerializer.scala
@@ -1,8 +1,8 @@
 package com.twitter.finatra.json.internal.serde
 
-import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.databind.SerializerProvider
-import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import __foursquare_shaded__.com.fasterxml.jackson.core.JsonGenerator
+import __foursquare_shaded__.com.fasterxml.jackson.databind.SerializerProvider
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ser.std.StdSerializer
 import com.twitter.util.Time
 
 private[finatra] object TimeStringSerializer extends StdSerializer[Time](classOf[Time]) {

--- a/jackson/src/main/scala/com/twitter/finatra/json/internal/streaming/AsyncJsonParser.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/internal/streaming/AsyncJsonParser.scala
@@ -1,8 +1,8 @@
 package com.twitter.finatra.json.internal.streaming
 
-import com.fasterxml.jackson.core.async.ByteArrayFeeder
-import com.fasterxml.jackson.core.json.async.NonBlockingJsonParser
-import com.fasterxml.jackson.core.{JsonFactory, JsonParser, JsonToken}
+import __foursquare_shaded__.com.fasterxml.jackson.core.async.ByteArrayFeeder
+import __foursquare_shaded__.com.fasterxml.jackson.core.json.async.NonBlockingJsonParser
+import __foursquare_shaded__.com.fasterxml.jackson.core.{JsonFactory, JsonParser, JsonToken}
 import com.twitter.io.Buf
 import java.nio.ByteBuffer
 import scala.collection.mutable.ListBuffer

--- a/jackson/src/main/scala/com/twitter/finatra/json/modules/FinatraJacksonModule.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/modules/FinatraJacksonModule.scala
@@ -1,12 +1,12 @@
 package com.twitter.finatra.json.modules
 
-import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.annotation.JsonInclude.Include
-import com.fasterxml.jackson.core.JsonGenerator.Feature
-import com.fasterxml.jackson.databind.{Module => JacksonModule, _}
-import com.fasterxml.jackson.datatype.joda.JodaModule
-import com.fasterxml.jackson.module.scala._
-import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.JsonInclude
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.JsonInclude.Include
+import __foursquare_shaded__.com.fasterxml.jackson.core.JsonGenerator.Feature
+import __foursquare_shaded__.com.fasterxml.jackson.databind.{Module => JacksonModule, _}
+import __foursquare_shaded__.com.fasterxml.jackson.datatype.joda.JodaModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala._
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 import com.google.inject.{Injector, Provides}
 import com.twitter.finatra.annotations.{CamelCaseMapper, SnakeCaseMapper}
 import com.twitter.finatra.json.FinatraObjectMapper

--- a/jackson/src/main/scala/com/twitter/finatra/json/modules/NullValidationCaseClassModule.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/modules/NullValidationCaseClassModule.scala
@@ -1,6 +1,6 @@
 package com.twitter.finatra.json.modules
 
-import com.fasterxml.jackson.module.scala._
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala._
 import com.twitter.finatra.json.internal.caseclass.jackson.{CaseClassDeserializers, NullCaseClassValidationProvider}
 
 /**

--- a/jackson/src/main/scala/com/twitter/finatra/json/utils/CamelCasePropertyNamingStrategy.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/utils/CamelCasePropertyNamingStrategy.scala
@@ -1,6 +1,6 @@
 package com.twitter.finatra.json.utils
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy
+import __foursquare_shaded__.com.fasterxml.jackson.databind.PropertyNamingStrategy
 
 /* By default PropertyNamingStrategy uses CamelCase */
 @deprecated(

--- a/jackson/src/main/scala/com/twitter/finatra/json/utils/JsonDiffResult.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/utils/JsonDiffResult.scala
@@ -1,6 +1,6 @@
 package com.twitter.finatra.json.utils
 
-import com.fasterxml.jackson.databind.JsonNode
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JsonNode
 import com.twitter.finatra.json.FinatraObjectMapper
 
 object JsonDiffResult {

--- a/jackson/src/main/scala/com/twitter/finatra/json/utils/JsonDiffUtil.scala
+++ b/jackson/src/main/scala/com/twitter/finatra/json/utils/JsonDiffUtil.scala
@@ -1,7 +1,7 @@
 package com.twitter.finatra.json.utils
 
-import com.fasterxml.jackson.databind.node.TextNode
-import com.fasterxml.jackson.databind.{JsonNode, ObjectMapperCopier, SerializationFeature}
+import __foursquare_shaded__.com.fasterxml.jackson.databind.node.TextNode
+import __foursquare_shaded__.com.fasterxml.jackson.databind.{JsonNode, ObjectMapperCopier, SerializationFeature}
 import com.twitter.finatra.json.FinatraObjectMapper
 import com.twitter.inject.Logging
 import com.twitter.inject.conversions.boolean._

--- a/jackson/src/test/scala/com/twitter/finatra/json/JsonDiff.scala
+++ b/jackson/src/test/scala/com/twitter/finatra/json/JsonDiff.scala
@@ -1,6 +1,6 @@
 package com.twitter.finatra.json
 
-import com.fasterxml.jackson.databind.JsonNode
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JsonNode
 import com.twitter.finatra.json.utils.{JsonDiffResult, JsonDiffUtil}
 import org.scalatest.exceptions.TestFailedException
 

--- a/jackson/src/test/scala/com/twitter/finatra/json/tests/FinatraObjectMapperTest.scala
+++ b/jackson/src/test/scala/com/twitter/finatra/json/tests/FinatraObjectMapperTest.scala
@@ -1,15 +1,15 @@
 package com.twitter.finatra.json.tests
 
-import com.fasterxml.jackson.core.`type`.TypeReference
-import com.fasterxml.jackson.databind.node.{IntNode, TreeTraversingParser}
-import com.fasterxml.jackson.databind.{
+import __foursquare_shaded__.com.fasterxml.jackson.core.`type`.TypeReference
+import __foursquare_shaded__.com.fasterxml.jackson.databind.node.{IntNode, TreeTraversingParser}
+import __foursquare_shaded__.com.fasterxml.jackson.databind.{
   JsonMappingException,
   JsonNode,
   ObjectMapper,
   PropertyNamingStrategy
 }
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.DefaultScalaModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finatra.annotations.{CamelCaseMapper, SnakeCaseMapper}
 import com.twitter.finatra.json.internal.caseclass.exceptions.{CaseClassMappingException, CaseClassValidationException, JsonInjectionNotSupportedException, RequestFieldInjectionNotSupportedException}

--- a/jackson/src/test/scala/com/twitter/finatra/json/tests/JsonDiffTest.scala
+++ b/jackson/src/test/scala/com/twitter/finatra/json/tests/JsonDiffTest.scala
@@ -1,6 +1,6 @@
 package com.twitter.finatra.json.tests
 
-import com.fasterxml.jackson.databind.JsonNode
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JsonNode
 import com.twitter.finatra.json.FinatraObjectMapper
 import com.twitter.finatra.json.JsonDiff._
 import com.twitter.finatra.json.utils.JsonDiffUtil

--- a/jackson/src/test/scala/com/twitter/finatra/json/tests/internal/JodaTimeModuleTest.scala
+++ b/jackson/src/test/scala/com/twitter/finatra/json/tests/internal/JodaTimeModuleTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.finatra.json.tests.internal
 
-import com.fasterxml.jackson.databind.{ObjectMapper, SerializationFeature}
-import com.fasterxml.jackson.datatype.joda.JodaModule
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import __foursquare_shaded__.com.fasterxml.jackson.databind.{ObjectMapper, SerializationFeature}
+import __foursquare_shaded__.com.fasterxml.jackson.datatype.joda.JodaModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.DefaultScalaModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 import com.twitter.finatra.json.FinatraObjectMapper
 import com.twitter.finatra.json.internal.serde.SerDeSimpleModule
 import com.twitter.inject.Test

--- a/jackson/src/test/scala/com/twitter/finatra/json/tests/internal/TwitterTimeStringDeserializerTest.scala
+++ b/jackson/src/test/scala/com/twitter/finatra/json/tests/internal/TwitterTimeStringDeserializerTest.scala
@@ -1,8 +1,8 @@
 package com.twitter.finatra.json.tests.internal
 
-import com.fasterxml.jackson.annotation.JsonFormat
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.JsonFormat
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ObjectMapper
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.twitter.finatra.json.internal.serde.SerDeSimpleModule
 import com.twitter.inject.Test
 import com.twitter.util.{Time, TimeFormat}

--- a/jackson/src/test/scala/com/twitter/finatra/json/tests/internal/caseclass/jackson/CaseClassFieldTest.scala
+++ b/jackson/src/test/scala/com/twitter/finatra/json/tests/internal/caseclass/jackson/CaseClassFieldTest.scala
@@ -1,10 +1,10 @@
 package com.twitter.finatra.json.tests.internal.caseclass.jackson
 
-import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty}
-import com.fasterxml.jackson.databind.PropertyNamingStrategy
-import com.fasterxml.jackson.databind.`type`.TypeFactory
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import com.fasterxml.jackson.databind.deser.std.NumberDeserializers.BigDecimalDeserializer
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty}
+import __foursquare_shaded__.com.fasterxml.jackson.databind.PropertyNamingStrategy
+import __foursquare_shaded__.com.fasterxml.jackson.databind.`type`.TypeFactory
+import __foursquare_shaded__.com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import __foursquare_shaded__.com.fasterxml.jackson.databind.deser.std.NumberDeserializers.BigDecimalDeserializer
 import com.twitter.finatra.json.internal.caseclass.jackson.{CaseClassField, NullCaseClassValidationProvider}
 import com.twitter.finatra.json.tests.internal.{WithEmptyJsonProperty, WithNonemptyJsonProperty, WithoutJsonPropertyAnnotation}
 import com.twitter.finatra.request.{Header, QueryParam}

--- a/jackson/src/test/scala/com/twitter/finatra/json/tests/internal/caseclass/jackson/caseclasses.scala
+++ b/jackson/src/test/scala/com/twitter/finatra/json/tests/internal/caseclass/jackson/caseclasses.scala
@@ -1,8 +1,8 @@
 package com.twitter.finatra.json.tests.internal.caseclass.jackson
 
-import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty}
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import com.fasterxml.jackson.databind.deser.std.NumberDeserializers.BigDecimalDeserializer
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty}
+import __foursquare_shaded__.com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import __foursquare_shaded__.com.fasterxml.jackson.databind.deser.std.NumberDeserializers.BigDecimalDeserializer
 import com.twitter.finatra.request.{Header, QueryParam}
 import com.twitter.finatra.response.JsonCamelCase
 import com.twitter.finatra.validation.NotEmpty

--- a/jackson/src/test/scala/com/twitter/finatra/json/tests/internal/caseclasses.scala
+++ b/jackson/src/test/scala/com/twitter/finatra/json/tests/internal/caseclasses.scala
@@ -1,10 +1,10 @@
 package com.twitter.finatra.json.tests.internal
 
-import com.fasterxml.jackson.annotation.{JsonIgnore, JsonIgnoreProperties, JsonProperty, JsonValue}
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import com.fasterxml.jackson.databind.node.ValueNode
+import __foursquare_shaded__.com.fasterxml.jackson.annotation.{JsonIgnore, JsonIgnoreProperties, JsonProperty, JsonValue}
+import __foursquare_shaded__.com.fasterxml.jackson.core.JsonParser
+import __foursquare_shaded__.com.fasterxml.jackson.databind._
+import __foursquare_shaded__.com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import __foursquare_shaded__.com.fasterxml.jackson.databind.node.ValueNode
 import com.twitter.finatra.request._
 import com.twitter.finatra.response.JsonCamelCase
 import com.twitter.finatra.validation.ValidationResult

--- a/jackson/src/test/scala/com/twitter/finatra/json/tests/internal/streaming/AsyncJsonParserTest.scala
+++ b/jackson/src/test/scala/com/twitter/finatra/json/tests/internal/streaming/AsyncJsonParserTest.scala
@@ -1,7 +1,7 @@
 package com.twitter.finatra.json.tests.internal.streaming
 
-import com.fasterxml.jackson.core.JsonParseException
-import com.fasterxml.jackson.databind.JsonNode
+import __foursquare_shaded__.com.fasterxml.jackson.core.JsonParseException
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JsonNode
 import com.twitter.finatra.json.{FinatraObjectMapper, JsonDiff}
 import com.twitter.finatra.json.internal.streaming.AsyncJsonParser
 import com.twitter.inject.Test

--- a/thrift/src/test/java/com/twitter/finatra/thrift/tests/DoEverythingJavaThriftServerFeatureTest.java
+++ b/thrift/src/test/java/com/twitter/finatra/thrift/tests/DoEverythingJavaThriftServerFeatureTest.java
@@ -5,8 +5,8 @@ import java.util.Map;
 
 import scala.reflect.ClassTag$;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import __foursquare_shaded__.com.fasterxml.jackson.databind.JsonNode;
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Stage;
 
 import org.apache.thrift.TApplicationException;

--- a/thrift/src/test/scala/com/twitter/finatra/thrift/tests/DoEverythingThriftServerFeatureTest.scala
+++ b/thrift/src/test/scala/com/twitter/finatra/thrift/tests/DoEverythingThriftServerFeatureTest.scala
@@ -1,8 +1,8 @@
 package com.twitter.finatra.thrift.tests
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import __foursquare_shaded__.com.fasterxml.jackson.databind.ObjectMapper
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.DefaultScalaModule
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 import com.twitter.conversions.DurationOps._
 import com.twitter.doeverything.thriftscala.{Answer, DoEverything, Question}
 import com.twitter.finagle.http.Status

--- a/validation/src/main/scala/com/twitter/finatra/validation/ErrorCode.scala
+++ b/validation/src/main/scala/com/twitter/finatra/validation/ErrorCode.scala
@@ -1,6 +1,6 @@
 package com.twitter.finatra.validation
 
-import com.fasterxml.jackson.core.JsonProcessingException
+import __foursquare_shaded__.com.fasterxml.jackson.core.JsonProcessingException
 import java.util.concurrent.TimeUnit
 import org.joda.time.DateTime
 


### PR DESCRIPTION
There are a handful of steps involved here:

 0. add our shaded core jackson-fatjar and jackson-module-scala jars
    to the repo's top-level lib directory (they are unmanaged
    dependencies in sbt's eyes)
 1. update build configuration to ban upstream jackson jars
 2. update jackson imports to use their shaded variants
 3. compile
 4. once everything compiles, comment out the upstream jackson
    excludes
 5. run tests
 6. uncomment the upstream jackson excludes
 7. bump the patch version and publish the shaded finatra jars
 8. test using the shaded jars locally
 9. upload the jars, javadocs, sources, and poms to artifactory. You
    won't need all of them -- I recommend bumping the patch version
    in foursquare.web first, running ivy resolve, and uploading
    missing artifacts until it succeeds
 10. make a new branch on our github fork off the upstream release
    tag (call it something like 20.1.0-fs), open a pr against that
    for review, then merge your changes and push a new git tag for
    the patch release (eg. finatra-20.1.0-fs0)

Code-wise, this is a dead simple namespace refactor. Unfortunately,
most of the complexity involved comes at runtime in the form of
manually validating the classpath is properly constructed. The repo's
test suite certainly helps and is a good place to start, however some
other checks to make:

 - in sbt, run `show test:fullClasspath` and verify it shows no
   versions of jackson other than our shaded fat jar
 - as an added sanity check, always unzip our shaded jackson jars and
   make sure they doesn't include unshaded jackson class files

Assuming you have done your due diligence on all of the above, your
newly shaded jars should be good to go!

There are some open questions on how sbt treats its test classpath.
Any tests using shaded jackson fail with classloading errors when
`fork in Test := true` is set but pass when it isn't, while there are
a small handful of tests using the scala-parser-combinators library
that fail only when `fork in Test := true` _isn't_ set (also
reproducible on upstream finatra!). While I would love answers, I'm
reasonably convinced these are sbt gremlins unrelated to the changes
here and have given up trying to find a fix.
